### PR TITLE
Add draft for CMake build framework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,57 @@
+cmake_minimum_required(VERSION 3.9)
+
+project(
+  "mstore"
+  LANGUAGES "Fortran"
+  VERSION "0.2.0"
+  DESCRIPTION "Modular computation tool chain"
+)
+
+# Follow GNU conventions for installing directories
+include(GNUInstallDirs)
+
+# Collect source of the project
+set(srcs)
+add_subdirectory("src")
+
+# Fetch external dependency
+include(FetchContent)
+FetchContent_Declare(
+  mctc-lib
+  GIT_REPOSITORY https://github.com/grimme-lab/mctc-lib.git
+  GIT_TAG main
+)
+FetchContent_GetProperties(mctc-lib)
+if(NOT mctc-lib_POPULATED)
+  FetchContent_Populate(mctc-lib)
+endif()
+set(${_package_upper}_SOURCE_DIR "${${_package_lower}_SOURCE_DIR}")
+set(${_package_upper}_BINARY_DIR "${${_package_lower}_BINARY_DIR}")
+add_subdirectory(${mctc-lib_SOURCE_DIR} ${mctc-lib_BINARY_DIR})
+
+# MCTC library target
+add_library(
+  "${PROJECT_NAME}-lib"
+  "${srcs}"
+)
+
+target_link_libraries(${PROJECT_NAME}-lib PUBLIC mctc-lib-lib)
+
+set_target_properties(
+  "${PROJECT_NAME}-lib"
+  PROPERTIES
+  POSITION_INDEPENDENT_CODE TRUE
+  OUTPUT_NAME "${PROJECT_NAME}"
+  VERSION "${PROJECT_VERSION}"
+  SOVERSION "${PROJECT_VERSION_MAJOR}"
+  Fortran_MODULE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include"
+)
+
+target_include_directories(
+  "${PROJECT_NAME}-lib"
+  PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+add_subdirectory(app)

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory(fortranize)
+add_subdirectory(info)

--- a/app/fortranize/CMakeLists.txt
+++ b/app/fortranize/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(srcs
+  main.f90
+)
+add_executable(fortranize ${srcs})
+target_link_libraries(fortranize mstore-lib)

--- a/app/info/CMakeLists.txt
+++ b/app/info/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(srcs
+  main.f90
+)
+add_executable(info ${srcs})
+target_link_libraries(info mstore-lib)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,25 @@
+# This file is part of mstore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_subdirectory("mstore")
+
+set(dir "${CMAKE_CURRENT_SOURCE_DIR}")
+
+list(
+  APPEND srcs
+  "${dir}/mstore.f90"
+  "${dir}/mstore_version.f90"
+)
+
+set(srcs "${srcs}" PARENT_SCOPE)

--- a/src/mstore/CMakeLists.txt
+++ b/src/mstore/CMakeLists.txt
@@ -1,0 +1,31 @@
+# This file is part of mctc-lib.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_subdirectory("data")
+
+set(dir "${CMAKE_CURRENT_SOURCE_DIR}")
+
+list(
+  APPEND srcs
+  "${dir}/amino20x4.f90"
+  "${dir}/but14diol.f90"
+  "${dir}/heavy28.f90"
+  "${dir}/ice10.f90"
+  "${dir}/il16.f90"
+  "${dir}/mb16_43.f90"
+  "${dir}/upu23.f90"
+  "${dir}/x23.f90"
+)
+
+set(srcs "${srcs}" PARENT_SCOPE)

--- a/src/mstore/data/CMakeLists.txt
+++ b/src/mstore/data/CMakeLists.txt
@@ -1,0 +1,24 @@
+# This file is part of mstore.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(dir "${CMAKE_CURRENT_SOURCE_DIR}")
+
+list(
+  APPEND srcs
+  "${dir}/collection.f90"
+  "${dir}/record.f90"
+  "${dir}/store.f90"
+)
+
+set(srcs "${srcs}" PARENT_SCOPE)


### PR DESCRIPTION
Absolutely basic CMake framework with FetchContent for mctc-lib, which seems to work. No install targets, no headers, etc. Feel free just to pick whatever you need and close this PR.